### PR TITLE
Make function definitions inline

### DIFF
--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -36,25 +36,25 @@ public:
     //!@{
 
     //! Sets a configuration { host, port, prefix }
-    inline void setConfig(const std::string& host, const uint16_t port, const std::string& prefix) noexcept;
+    void setConfig(const std::string& host, const uint16_t port, const std::string& prefix) noexcept;
 
     //! Returns the error message as an optional std::string
-    inline std::optional<std::string> errorMessage() const noexcept;
+    std::optional<std::string> errorMessage() const noexcept;
 
     //! Increments the key, at a given frequency rate
-    inline void increment(const std::string& key, const float frequency = 1.0f) const noexcept;
+    void increment(const std::string& key, const float frequency = 1.0f) const noexcept;
 
     //! Increments the key, at a given frequency rate
-    inline void decrement(const std::string& key, const float frequency = 1.0f) const noexcept;
+    void decrement(const std::string& key, const float frequency = 1.0f) const noexcept;
 
     //! Adjusts the specified key by a given delta, at a given frequency rate
-    inline void count(const std::string& key, const int delta, const float frequency = 1.0f) const noexcept;
+    void count(const std::string& key, const int delta, const float frequency = 1.0f) const noexcept;
 
     //! Records a gauge for the key, with a given value, at a given frequency rate
-    inline void gauge(const std::string& key, const unsigned int value, const float frequency = 1.0f) const noexcept;
+    void gauge(const std::string& key, const unsigned int value, const float frequency = 1.0f) const noexcept;
 
     //! Records a timing for a key, at a given frequency
-    inline void timing(const std::string& key, const unsigned int ms, const float frequency = 1.0f) const noexcept;
+    void timing(const std::string& key, const unsigned int ms, const float frequency = 1.0f) const noexcept;
 
     //! Send a value for a key, according to its type, at a given frequency
     void send(const std::string& key, const int value, const std::string& type, const float frequency = 1.0f) const
@@ -70,7 +70,7 @@ private:
     mutable UDPSender m_sender;
 };
 
-StatsdClient::StatsdClient(const std::string& host,
+inline StatsdClient::StatsdClient(const std::string& host,
                            const uint16_t port,
                            const std::string& prefix,
                            const std::optional<uint64_t> batchsize) noexcept
@@ -79,36 +79,36 @@ StatsdClient::StatsdClient(const std::string& host,
     std::srand(time(nullptr));
 }
 
-void StatsdClient::setConfig(const std::string& host, const uint16_t port, const std::string& prefix) noexcept {
+inline void StatsdClient::setConfig(const std::string& host, const uint16_t port, const std::string& prefix) noexcept {
     m_prefix = prefix;
     m_sender.setConfig(host, port);
 }
 
-std::optional<std::string> StatsdClient::errorMessage() const noexcept {
+inline std::optional<std::string> StatsdClient::errorMessage() const noexcept {
     return m_sender.errorMessage();
 }
 
-void StatsdClient::decrement(const std::string& key, const float frequency) const noexcept {
+inline void StatsdClient::decrement(const std::string& key, const float frequency) const noexcept {
     return count(key, -1, frequency);
 }
 
-void StatsdClient::increment(const std::string& key, const float frequency) const noexcept {
+inline void StatsdClient::increment(const std::string& key, const float frequency) const noexcept {
     return count(key, 1, frequency);
 }
 
-void StatsdClient::count(const std::string& key, const int delta, const float frequency) const noexcept {
+inline void StatsdClient::count(const std::string& key, const int delta, const float frequency) const noexcept {
     return send(key, delta, "c", frequency);
 }
 
-void StatsdClient::gauge(const std::string& key, const unsigned int value, const float frequency) const noexcept {
+inline void StatsdClient::gauge(const std::string& key, const unsigned int value, const float frequency) const noexcept {
     return send(key, value, "g", frequency);
 }
 
-void StatsdClient::timing(const std::string& key, const unsigned int ms, const float frequency) const noexcept {
+inline void StatsdClient::timing(const std::string& key, const unsigned int ms, const float frequency) const noexcept {
     return send(key, ms, "ms", frequency);
 }
 
-void StatsdClient::send(const std::string& key, const int value, const std::string& type, const float frequency) const
+inline void StatsdClient::send(const std::string& key, const int value, const std::string& type, const float frequency) const
     noexcept {
     const auto isFrequencyOne = [](const float frequency) noexcept {
         constexpr float epsilon{0.0001f};

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -43,13 +43,13 @@ public:
     //!@{
 
     //! Sets a configuration { host, port }
-    inline void setConfig(const std::string& host, const uint16_t port) noexcept;
+    void setConfig(const std::string& host, const uint16_t port) noexcept;
 
     //! Send a message
     void send(const std::string& message) noexcept;
 
     //! Returns the error message as an optional string
-    inline std::optional<std::string> errorMessage() const noexcept;
+    std::optional<std::string> errorMessage() const noexcept;
 
     //!@}
 
@@ -118,7 +118,7 @@ private:
     std::optional<std::string> m_errorMessage;
 };
 
-UDPSender::UDPSender(const std::string& host, const uint16_t port, const std::optional<uint64_t> batchsize) noexcept
+inline UDPSender::UDPSender(const std::string& host, const uint16_t port, const std::optional<uint64_t> batchsize) noexcept
     : m_host(host), m_port(port) {
     // If batching is on, use a dedicated thread to send every now and then
     if (batchsize) {
@@ -151,7 +151,7 @@ UDPSender::UDPSender(const std::string& host, const uint16_t port, const std::op
     }
 }
 
-UDPSender::~UDPSender() {
+inline UDPSender::~UDPSender() {
     if (m_batching) {
         m_mustExit = true;
         m_batchingThread.join();
@@ -163,7 +163,7 @@ UDPSender::~UDPSender() {
     }
 }
 
-void UDPSender::setConfig(const std::string& host, const uint16_t port) noexcept {
+inline void UDPSender::setConfig(const std::string& host, const uint16_t port) noexcept {
     m_host = host;
     m_port = port;
 
@@ -175,7 +175,7 @@ void UDPSender::setConfig(const std::string& host, const uint16_t port) noexcept
     m_socket = -1;
 }
 
-void UDPSender::send(const std::string& message) noexcept {
+inline void UDPSender::send(const std::string& message) noexcept {
     // If batching is on, accumulate messages in the queue
     if (m_batching) {
         std::unique_lock<std::mutex> batchingLock(m_batchingMutex);
@@ -189,11 +189,11 @@ void UDPSender::send(const std::string& message) noexcept {
     }
 }
 
-std::optional<std::string> UDPSender::errorMessage() const noexcept {
+inline std::optional<std::string> UDPSender::errorMessage() const noexcept {
     return m_errorMessage;
 }
 
-bool UDPSender::initialize() noexcept {
+inline bool UDPSender::initialize() noexcept {
     using namespace std::string_literals;
 
     if (m_isInitialized) {
@@ -243,7 +243,7 @@ bool UDPSender::initialize() noexcept {
     return true;
 }
 
-void UDPSender::sendToDaemon(const std::string& message) noexcept {
+inline void UDPSender::sendToDaemon(const std::string& message) noexcept {
     // Can't send until the sender is initialized
     if (!initialize()) {
         return;


### PR DESCRIPTION
Using the library in two separate source files was leading to multiple definition errors, as the `inline` specifier needs to be used in the definition rather than the declaration.

A few links that helped me understand how exactly `inline` quite works in C++ 😊 :
  - https://pabloariasal.github.io/2019/02/28/cpp-inlining/
  - https://isocpp.org/wiki/faq/inline-functions#where-to-put-inline-keyword