### PR TITLE
Backport to c++11 and Add Back CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -24,5 +24,5 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=.:$(cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g")
           #TODO: run statsd to collect these test metrics
-          testStatsdClient
+          ./testStatsdClient
           #TODO: validate test metrics received

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,0 +1,28 @@
+name: linux
+on: [pull_request]
+
+jobs:
+  build:
+    name: build and test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq make cmake gcc g++
+      - name: build
+        shell: bash
+        run: |
+          export LD_LIBRARY_PATH=.:$(cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g")
+          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On && make all -j$(nproc)
+      - name: test
+        shell: bash
+        run: |
+          export LD_LIBRARY_PATH=.:$(cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g")
+          #TODO: run statsd to collect these test metrics
+          testStatsdClient
+          #TODO: validate test metrics received

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(StatsdClient)
 cmake_minimum_required(VERSION 3.2)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CPP_STATSD_CLIENT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/cpp-statsd-client)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![logo](https://raw.githubusercontent.com/vthiery/cpp-statsd-client/master/images/logo.svg?sanitize=true)
 
 [![Download](https://api.bintray.com/packages/vthiery/conan-packages/statsdclient%3Avthiery/images/download.svg)](https://bintray.com/vthiery/conan-packages/statsdclient%3Avthiery/_latestVersion)
-[![Build Status](https://travis-ci.org/vthiery/cpp-statsd-client.svg?branch=master)](https://travis-ci.org/vthiery/cpp-statsd-client)
+![Build Status](https://github.com/vthiery/cpp-statsd-client/actions/workflows/linux/badge.svg)
 [![Github Issues](https://img.shields.io/github/issues/vthiery/cpp-statsd-client.svg)](https://github.com/vthiery/cpp-statsd-client/issues)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vthiery/cpp-statsd-client.svg)](http://isitmaintained.com/project/vthiery/cpp-statsd-client "Average time to resolve an issue")
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![logo](https://raw.githubusercontent.com/vthiery/cpp-statsd-client/master/images/logo.svg?sanitize=true)
 
 [![Download](https://api.bintray.com/packages/vthiery/conan-packages/statsdclient%3Avthiery/images/download.svg)](https://bintray.com/vthiery/conan-packages/statsdclient%3Avthiery/_latestVersion)
-![Build Status](https://github.com/vthiery/cpp-statsd-client/actions/workflows/linux/badge.svg)
+[![Build Status](https://github.com/vthiery/cpp-statsd-client/actions/workflows/linux/badge.svg)](https://github.com/vthiery/cpp-statsd-client/actions?workflow=linux)
 [![Github Issues](https://img.shields.io/github/issues/vthiery/cpp-statsd-client.svg)](https://github.com/vthiery/cpp-statsd-client/issues)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vthiery/cpp-statsd-client.svg)](http://isitmaintained.com/project/vthiery/cpp-statsd-client "Average time to resolve an issue")
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The batchsize is the only parameter that cannot be changed for the time being.
 The client supports batching of the metrics:
 
 - the unit of the batching parameter is bytes,
-- it is optional and not setting it will result in an immediate send of any metrics,
+- it is optional and passing a 0 will result in an immediate send of any metrics,
 
 If set, the UDP sender will spawn a thread sending the metrics to the server every 1 second by aggregates. The aggregation logic is as follows:
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -27,7 +27,7 @@ public:
     StatsdClient(const std::string& host,
                  const uint16_t port,
                  const std::string& prefix,
-                 const uint64_t batchsize = std::numeric_limits<uint64_t>::max()) noexcept;
+                 const uint64_t batchsize = 0) noexcept;
 
     //!@}
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -2,7 +2,6 @@
 #define STATSD_CLIENT_HPP
 
 #include <cstdlib>
-#include <optional>
 #include <string>
 #include "UDPSender.hpp"
 
@@ -28,7 +27,7 @@ public:
     StatsdClient(const std::string& host,
                  const uint16_t port,
                  const std::string& prefix,
-                 const std::optional<uint64_t> batchsize = std::nullopt) noexcept;
+                 const uint64_t batchsize = std::numeric_limits<uint64_t>::max()) noexcept;
 
     //!@}
 
@@ -39,7 +38,7 @@ public:
     void setConfig(const std::string& host, const uint16_t port, const std::string& prefix) noexcept;
 
     //! Returns the error message as an optional std::string
-    std::optional<std::string> errorMessage() const noexcept;
+    const std::string& errorMessage() const noexcept;
 
     //! Increments the key, at a given frequency rate
     void increment(const std::string& key, const float frequency = 1.0f) const noexcept;
@@ -73,7 +72,7 @@ private:
 inline StatsdClient::StatsdClient(const std::string& host,
                                   const uint16_t port,
                                   const std::string& prefix,
-                                  const std::optional<uint64_t> batchsize) noexcept
+                                  const uint64_t batchsize) noexcept
     : m_prefix(prefix), m_sender(host, port, batchsize) {
     // Initialize the randorm generator to be used for sampling
     std::srand(time(nullptr));
@@ -84,7 +83,7 @@ inline void StatsdClient::setConfig(const std::string& host, const uint16_t port
     m_sender.setConfig(host, port);
 }
 
-inline std::optional<std::string> StatsdClient::errorMessage() const noexcept {
+inline const std::string& StatsdClient::errorMessage() const noexcept {
     return m_sender.errorMessage();
 }
 

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -32,7 +32,7 @@ public:
     //! Constructor
     UDPSender(const std::string& host,
               const uint16_t port,
-              const uint64_t batchsize = std::numeric_limits<uint64_t>::max()) noexcept;
+              const uint64_t batchsize = 0) noexcept;
 
     //! Destructor
     ~UDPSender();
@@ -123,7 +123,7 @@ inline UDPSender::UDPSender(const std::string& host,
                             const uint64_t batchsize) noexcept
     : m_host(host), m_port(port) {
     // If batching is on, use a dedicated thread to send every now and then
-    if (batchsize != std::numeric_limits<uint64_t>::max()) {
+    if (batchsize != 0) {
         // Thread' sleep duration between batches
         // TODO: allow to input this
         constexpr unsigned int batchingWait{1000U};

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -1,37 +1,65 @@
 #include <StatsdClient.hpp>
 #include <cassert>
+#include <iostream>
 
 using namespace Statsd;
 
-int main() {
-    StatsdClient client{"localhost", 8080, "myPrefix.", 20};
+int main(int argc, char** argv) {
+    // connect to a rubbish port and make sure initialization failed
+    StatsdClient client{"256.256.256.256", 8125, "myPrefix.", 20};
+    if (client.errorMessage().empty()) {
+        std::cerr << "should not be able to connect to ridiculous ip" << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // set a new config with a different port
-    client.setConfig("localhost", 8000, "myPrefix.");
+    client.setConfig("localhost", 8125, "myPrefix.");
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Increment "coco"
     client.increment("coco");
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Decrement "kiki"
     client.decrement("kiki");
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Adjusts "toto" by +3
     client.count("toto", 2, 0.1f);
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Record a gauge "titi" to 3
     client.gauge("titi", 3);
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Record a timing of 2ms for "myTiming"
     client.timing("myTiming", 2, 0.1f);
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Send a metric explicitly
     client.send("tutu", 4, "c", 2.0f);
-    assert(client.errorMessage().empty());
+    if (!client.errorMessage().empty()) {
+        std::cerr << client.errorMessage() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -11,27 +11,27 @@ int main() {
 
     // Increment "coco"
     client.increment("coco");
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     // Decrement "kiki"
     client.decrement("kiki");
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     // Adjusts "toto" by +3
     client.count("toto", 2, 0.1f);
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     // Record a gauge "titi" to 3
     client.gauge("titi", 3);
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     // Record a timing of 2ms for "myTiming"
     client.timing("myTiming", 2, 0.1f);
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     // Send a metric explicitly
     client.send("tutu", 4, "c", 2.0f);
-    assert(!client.errorMessage());
+    assert(client.errorMessage().empty());
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hi! I'm not sure if you are accepting pull requests at the moment but I found your library and thought it looked useful. There were a couple of things stopping me from using it thought. The project I was looking to use it in is and open source routing engine which you can find here: https://github.com/valhalla/valhalla This routing engine is often run in a server environment and it would be great to collect metrics from it via statsd integration, which is what brought me here!

Sadly the project is targetting c++14 at the moment to maintain compatibility with older build systems with older compilers, usually for embedded systems like the Tesla in-car navigation system and other bespoke vehicle navigation systems. This meant that I needed to backport the code in a couple places (I chose to target c++11 since it has wide compatibility over the last decade). I'll make annotations to the diff to explain those changes.

The other thing I noticed is that this project is still targetting travis which semi-recently removed free support. So I've added github actions CI which builds and tests (though I haven't fully finished the testing) the code.

Let me know if some or any of these contributions would be welcome and thanks again for providing this library! 