### PR TITLE
Update Cmake to Make Library Easier to Use in Downstream Projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-
+find_package(Threads)
 
 # The library target
 add_library(${PROJECT_NAME} INTERFACE)
@@ -17,6 +17,7 @@ target_include_directories(
   ${PROJECT_NAME}
   INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
 
 # The installation and pkg-config-like cmake config
 install(TARGETS ${PROJECT_NAME}
@@ -42,12 +43,12 @@ install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION include)
 
 # The test targets
-find_package(Threads)
 add_executable(testStatsdClient ${CMAKE_CURRENT_SOURCE_DIR}/tests/testStatsdClient.cpp)
 target_compile_options(testStatsdClient PRIVATE -Wall -Wextra -pedantic -Werror)
 target_include_directories(testStatsdClient PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-target_link_libraries(testStatsdClient ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_NAME})
+target_link_libraries(testStatsdClient ${PROJECT_NAME})
 
 # The test suite
 enable_testing()
-add_test(testSuite testStatsdClient)
+add_test(ctestTestStatsdClient testStatsdClient)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS testStatsdClient)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,51 @@
-project(StatsdClient)
-cmake_minimum_required(VERSION 3.2)
-
+# Basic project setup
+cmake_minimum_required(VERSION 3.5)
+project(cpp-statsd-client
+        VERSION 1.0.2
+        LANGUAGES CXX
+        DESCRIPTION "A header-only StatsD client implemented in C++"
+        HOMEPAGE_URL "https://github.com/vthiery/cpp-statsd-client")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CPP_STATSD_CLIENT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/cpp-statsd-client)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-include_directories(${CPP_STATSD_CLIENT_DIR})
 
-install(DIRECTORY ${CPP_STATSD_CLIENT_DIR} DESTINATION include)
+# The library target
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}
+  INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+# The installation and pkg-config-like cmake config
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}_Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY SameMajorVersion)
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+install(EXPORT ${PROJECT_NAME}_Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+              "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION include)
+
+# The test targets
 find_package(Threads)
 add_executable(testStatsdClient ${CMAKE_CURRENT_SOURCE_DIR}/tests/testStatsdClient.cpp)
-target_link_libraries(testStatsdClient ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(testStatsdClient ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_NAME})
 
+# The test suite
 enable_testing()
 add_test(testSuite testStatsdClient)
-
-unset(CPP_STATSD_CLIENT_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION include)
 # The test targets
 find_package(Threads)
 add_executable(testStatsdClient ${CMAKE_CURRENT_SOURCE_DIR}/tests/testStatsdClient.cpp)
+target_compile_options(testStatsdClient PRIVATE -Wall -Wextra -pedantic -Werror)
 target_include_directories(testStatsdClient PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 target_link_libraries(testStatsdClient ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_NAME})
 

--- a/cmake/cpp-statsd-clientConfig.cmake.in
+++ b/cmake/cpp-statsd-clientConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -1,10 +1,10 @@
 #ifndef STATSD_CLIENT_HPP
 #define STATSD_CLIENT_HPP
 
+#include <cpp-statsd-client/UDPSender.hpp>
 #include <cstdlib>
 #include <memory>
 #include <string>
-#include "UDPSender.hpp"
 
 namespace Statsd {
 /*!

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -1,6 +1,6 @@
-#include <cassert>
-#include <cpp-statsd-client/StatsdClient.hpp>
 #include <iostream>
+
+#include "cpp-statsd-client/StatsdClient.hpp"
 
 using namespace Statsd;
 

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "StatsdServer.hpp"
 #include "cpp-statsd-client/StatsdClient.hpp"
 
 using namespace Statsd;

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -137,7 +137,7 @@ void testSendRecv(uint64_t batchSize) {
     }
 }
 
-int main(int argc, char** argv) {
+int main() {
     // If any of these tests fail they throw an exception, not catching makes for a nonzero return code
 
     // general things that should be errors

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -1,5 +1,5 @@
-#include <StatsdClient.hpp>
 #include <cassert>
+#include <cpp-statsd-client/StatsdClient.hpp>
 #include <iostream>
 
 using namespace Statsd;


### PR DESCRIPTION
fixes #23 

The primary changes here are:

1. make an actual library target as an interface so that downstream targets can depend on it
2. fill out the basic project info
3. install package config files for cmake discoverability
4. fix include directives so that installations of the library will work properly (ie in the case someone installs rather than vendors the library)