### PR TITLE
handle the dot between prefix and key automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Basic project setup
 cmake_minimum_required(VERSION 3.5)
 project(cpp-statsd-client
-        VERSION 1.0.2
+        VERSION 2.0.0
         LANGUAGES CXX
         DESCRIPTION "A header-only StatsD client implemented in C++"
         HOMEPAGE_URL "https://github.com/vthiery/cpp-statsd-client")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Basic project setup
 cmake_minimum_required(VERSION 3.5)
 project(cpp-statsd-client
-        VERSION 2.0.0
+        VERSION 1.0.2
         LANGUAGES CXX
         DESCRIPTION "A header-only StatsD client implemented in C++"
         HOMEPAGE_URL "https://github.com/vthiery/cpp-statsd-client")

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ using namespace Statsd;
 
 int main() {
     // Define the client on localhost, with port 8080, using a prefix and a batching size of 20 bytes
-    StatsdClient client{ "127.0.0.1", 8080, "myPrefix.", 20 };
+    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20 };
 
     // Increment the metric "coco"
     client.increment("coco");
@@ -85,7 +85,7 @@ struct MyApp {
         m_client.count("bar", 3);
     }
 private:
-    StatsdClient m_client{"localhost", 8125, "foo."};
+    StatsdClient m_client{"localhost", 8125, "foo"};
 };
 
 int main() {
@@ -110,12 +110,12 @@ using namespace Statsd;
 int main()
 {
     // Define the client on localhost, with port 8080, using a prefix and a batching size of 20 bytes
-    StatsdClient client{ "127.0.0.1", 8080, "myPrefix.", 20 };
+    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20 };
 
     client.increment("coco");
 
     // Set a new configuration, using a different port and a different prefix
-    client.setConfig("127.0.0.1", 8000, "anotherPrefix.");
+    client.setConfig("127.0.0.1", 8000, "anotherPrefix");
 
     client.decrement("kiki");
 }

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -8,10 +8,6 @@
 #include <random>
 #include <string>
 
-#define STATSD_CLIENT_VERSION_MAJOR 2
-#define STATSD_CLIENT_VERSION_MINOR 0
-#define STATSD_CLIENT_VERSION_PATCH 0
-
 namespace Statsd {
 
 /*!

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -57,9 +57,20 @@ void testReconfigure() {
         throw std::runtime_error("Incorrect stat received");
     }
 
-    client.setConfig("localhost", 8125, "second.");
+    client.setConfig("localhost", 8125, "second");
     client.send("bar", 1, "c", 1.f);
     if (server.receive() != "second.bar:1|c") {
+        throw std::runtime_error("Incorrect stat received");
+    }
+
+    client.setConfig("localhost", 8125, "");
+    client.send("third.baz", 1, "c", 1.f);
+    if (server.receive() != "third.baz:1|c") {
+        throw std::runtime_error("Incorrect stat received");
+    }
+
+    client.send("", 1, "c", 1.f);
+    if (server.receive() != ":1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
@@ -90,7 +101,7 @@ void testSendRecv(uint64_t batchSize) {
         throwOnError(client);
         expected.emplace_back("sendRecv.kiki:-1|c");
 
-        // Adjusts "toto" by +3
+        // Adjusts "toto" by +2
         client.seed(19);  // this seed gets a hit on the first call
         client.count("toto", 2, 0.1f);
         throwOnError(client);
@@ -112,9 +123,9 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.myTiming:2|ms|@0.10");
 
         // Send a metric explicitly
-        client.send("tutu", 4, "c", 2.0f);
+        client.send("tutu", 241, "c", 2.0f);
         throwOnError(client);
-        expected.emplace_back("sendRecv.tutu:4|c");
+        expected.emplace_back("sendRecv.tutu:241|c");
     }
 
     // Signal the mock server we are done


### PR DESCRIPTION
fixe #27 

this also updates doc strings and README exmaples and since it is API breaking it adds version macros. let me know if i should remove the macros, i know we didnt really discuss them before.