### PR TITLE
Allocation Optimizations

### DIFF
--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -172,13 +172,18 @@ inline void StatsdClient::send(const std::string& key,
 
     // Format the stat message
     m_buffer.clear();
+    
     m_buffer.append(m_prefix);
-    if (!m_prefix.empty() && !key.empty()) m_buffer.push_back('.');
+    if (!m_prefix.empty() && !key.empty()) {
+        m_buffer.push_back('.');
+    }
+    
     m_buffer.append(key);
     m_buffer.push_back(':');
     m_buffer.append(std::to_string(value));
     m_buffer.push_back('|');
     m_buffer.append(type);
+    
     if (frequency < 1.f) {
         m_buffer.append("|@0.");
         m_buffer.append(std::to_string(static_cast<int>(frequency * 100)));

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -172,18 +172,18 @@ inline void StatsdClient::send(const std::string& key,
 
     // Format the stat message
     m_buffer.clear();
-    
+
     m_buffer.append(m_prefix);
     if (!m_prefix.empty() && !key.empty()) {
         m_buffer.push_back('.');
     }
-    
+
     m_buffer.append(key);
     m_buffer.push_back(':');
     m_buffer.append(std::to_string(value));
     m_buffer.push_back('|');
     m_buffer.append(type);
-    
+
     if (frequency < 1.f) {
         m_buffer.append("|@0.");
         m_buffer.append(std::to_string(static_cast<int>(frequency * 100)));

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -236,7 +236,7 @@ inline bool UDPSender::initialize() noexcept {
 inline void UDPSender::sendToDaemon(const std::string& message) noexcept {
     // Try sending the message
     const long int ret{
-        sendto(m_socket, &message.front(), message.size(), 0, (struct sockaddr*)&m_server, sizeof(m_server))};
+        sendto(m_socket, message.data(), message.size(), 0, (struct sockaddr*)&m_server, sizeof(m_server))};
     if (ret == -1) {
         m_errorMessage =
             "sendto server failed: host=" + m_host + ":" + std::to_string(m_port) + ", err=" + std::strerror(errno);

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -42,13 +42,6 @@ void testErrorConditions() {
     // Resolve a rubbish ip and make sure initialization failed
     StatsdClient client{"256.256.256.256", 8125, "myPrefix", 20};
     throwOnError(client, false, "Should not be able to resolve a ridiculous ip");
-
-    // Sending a message that is too large should fail
-    client.setConfig("localhost", 8125, "foo");
-    std::string long_key(333, 'X');
-    throwOnError(client);
-    client.send(long_key, 42, "ms");
-    throwOnError(client, false, "Should not be able to send stats this long");
 }
 
 void testReconfigure() {

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -31,21 +31,24 @@ void mock(StatsdServer& server, std::vector<std::string>& messages) {
     } while (server.errorMessage().empty() && !messages.back().empty());
 }
 
-// TODO: would it be ok if we change the API of the client to throw on error instead of having to check a string?
-void throwOnError(const StatsdClient& client) {
-    if (!client.errorMessage().empty()) {
-        std::cerr << client.errorMessage() << std::endl;
-        throw std::runtime_error(client.errorMessage());
+void throwOnError(const StatsdClient& client, bool expectEmpty = true, const std::string& extraMessage = "") {
+    if (client.errorMessage().empty() != expectEmpty) {
+        std::cerr << (expectEmpty ? client.errorMessage() : extraMessage) << std::endl;
+        throw std::runtime_error(expectEmpty ? client.errorMessage() : extraMessage);
     }
 }
 
 void testErrorConditions() {
-    // Connect to a rubbish ip and make sure initialization failed
+    // Resolve a rubbish ip and make sure initialization failed
     StatsdClient client{"256.256.256.256", 8125, "myPrefix.", 20};
-    if (client.errorMessage().empty()) {
-        std::cerr << "Should not be able to connect to ridiculous ip" << std::endl;
-        throw std::runtime_error("Should not be able to connect to ridiculous ip");
-    }
+    throwOnError(client, false, "Should not be able to resolve a ridiculous ip");
+
+    // Sending a message that is too large should fail
+    client.setConfig("localhost", 8125, "foo");
+    std::string long_key(333, 'X');
+    throwOnError(client);
+    client.send(long_key, 42, "ms");
+    throwOnError(client, false, "Should not be able to send stats this long");
 }
 
 void testReconfigure() {


### PR DESCRIPTION
In a previous PR I noticed that we instantiated a `char[]` only to copy it into a string and then potentially copy that string further on down the chain. In that previous PR I changed the `char[]` to a fixed size string but still the string was being allocated on ever call to `send` and again potentially copied.

This PR moves that buffer to a member variable, to which we write our messages and from which we read to send bytes over the socket. When in batching mode I've also made some changes to remove as many re-allocations as possible (by reserving the batch size for any new batches that are made). I've changed the send interface of the `UDPSender` to use iterators so that we don't copy any bytes from the `StatsdClient` to the `UDPSender`.

One strange quirk that I noticed a while back that we dont handle is when a person tries to send a stat that is larger than our buffer. `snprintf` tells us when this happens but we previously didnt do anything about it. i've added a unit test for that case but annoyingly since the `UDPSender` owns the error message it was somewhat un-tidy to allow the `StatsdClient` to set this message.