### PR TITLE
Add Missing Metric Types and Tags Support

### DIFF
--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -87,13 +87,6 @@ public:
                 float frequency = 1.0f,
                 const std::vector<std::string>& tags = {}) const noexcept;
 
-    //! Records an arbitrary unit for a key, at a given frequency. An alias for timing
-    //! suited to use cases whose units do not involve time
-    void histogram(const std::string& key,
-                   const unsigned int value,
-                   float frequency = 1.0f,
-                   const std::vector<std::string>& tags = {}) const noexcept;
-
     //! Records a count of unique occurrences for a key, at a given frequency
     void set(const std::string& key,
              const unsigned int sum,
@@ -145,7 +138,6 @@ std::string sanitizePrefix(std::string prefix) {
 constexpr char METRIC_TYPE_COUNT[] = "c";
 constexpr char METRIC_TYPE_GUAGE[] = "g";
 constexpr char METRIC_TYPE_TIMING[] = "ms";
-constexpr char METRIC_TYPE_HISTOGRAM[] = "h";
 constexpr char METRIC_TYPE_SET[] = "s";
 }  // namespace detail
 
@@ -203,13 +195,6 @@ inline void StatsdClient::timing(const std::string& key,
                                  float frequency,
                                  const std::vector<std::string>& tags) const noexcept {
     return send(key, ms, detail::METRIC_TYPE_TIMING, frequency, tags);
-}
-
-inline void StatsdClient::histogram(const std::string& key,
-                                    const unsigned int value,
-                                    float frequency,
-                                    const std::vector<std::string>& tags) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency, tags);
 }
 
 inline void StatsdClient::set(const std::string& key,

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <vector>
 
 namespace Statsd {
 
@@ -59,26 +60,45 @@ public:
     const std::string& errorMessage() const noexcept;
 
     //! Increments the key, at a given frequency rate
-    void increment(const std::string& key, float frequency = 1.0f) const noexcept;
+    void increment(const std::string& key,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Increments the key, at a given frequency rate
-    void decrement(const std::string& key, float frequency = 1.0f) const noexcept;
+    void decrement(const std::string& key,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Adjusts the specified key by a given delta, at a given frequency rate
-    void count(const std::string& key, const int delta, float frequency = 1.0f) const noexcept;
+    void count(const std::string& key,
+               const int delta,
+               float frequency = 1.0f,
+               const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a gauge for the key, with a given value, at a given frequency rate
-    void gauge(const std::string& key, const unsigned int value, float frequency = 1.0f) const noexcept;
+    void gauge(const std::string& key,
+               const unsigned int value,
+               float frequency = 1.0f,
+               const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a timing for a key, at a given frequency
-    void timing(const std::string& key, const unsigned int ms, float frequency = 1.0f) const noexcept;
+    void timing(const std::string& key,
+                const unsigned int ms,
+                float frequency = 1.0f,
+                const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records an arbitrary unit for a key, at a given frequency. An alias for timing
     //! suited to use cases whose units do not involve time
-    void histogram(const std::string& key, const unsigned int value, float frequency = 1.0f) const noexcept;
+    void histogram(const std::string& key,
+                   const unsigned int value,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a count of unique occurrences for a key, at a given frequency
-    void set(const std::string& key, const unsigned int sum, float frequency = 1.0f) const noexcept;
+    void set(const std::string& key,
+             const unsigned int sum,
+             float frequency = 1.0f,
+             const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Seed the RNG that controls sampling
     void seed(unsigned int seed = std::random_device()()) noexcept;
@@ -90,7 +110,11 @@ private:
     // @{
 
     //! Send a value for a key, according to its type, at a given frequency
-    void send(const std::string& key, const int value, const char* type, float frequency = 1.0f) const noexcept;
+    void send(const std::string& key,
+              const int value,
+              const char* type,
+              float frequency,
+              const std::vector<std::string>& tags) const noexcept;
 
     //!@}
 
@@ -148,40 +172,58 @@ inline const std::string& StatsdClient::errorMessage() const noexcept {
     return m_sender->errorMessage();
 }
 
-inline void StatsdClient::decrement(const std::string& key, float frequency) const noexcept {
-    return count(key, -1, frequency);
+inline void StatsdClient::decrement(const std::string& key,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return count(key, -1, frequency, tags);
 }
 
-inline void StatsdClient::increment(const std::string& key, float frequency) const noexcept {
-    return count(key, 1, frequency);
+inline void StatsdClient::increment(const std::string& key,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return count(key, 1, frequency, tags);
 }
 
-inline void StatsdClient::count(const std::string& key, const int delta, float frequency) const noexcept {
-    return send(key, delta, detail::METRIC_TYPE_COUNT, frequency);
+inline void StatsdClient::count(const std::string& key,
+                                const int delta,
+                                float frequency,
+                                const std::vector<std::string>& tags) const noexcept {
+    return send(key, delta, detail::METRIC_TYPE_COUNT, frequency, tags);
 }
 
 inline void StatsdClient::gauge(const std::string& key,
                                 const unsigned int value,
-                                const float frequency) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_GUAGE, frequency);
+                                const float frequency,
+                                const std::vector<std::string>& tags) const noexcept {
+    return send(key, value, detail::METRIC_TYPE_GUAGE, frequency, tags);
 }
 
-inline void StatsdClient::timing(const std::string& key, const unsigned int ms, float frequency) const noexcept {
-    return send(key, ms, detail::METRIC_TYPE_TIMING, frequency);
+inline void StatsdClient::timing(const std::string& key,
+                                 const unsigned int ms,
+                                 float frequency,
+                                 const std::vector<std::string>& tags) const noexcept {
+    return send(key, ms, detail::METRIC_TYPE_TIMING, frequency, tags);
 }
 
-inline void StatsdClient::histogram(const std::string& key, const unsigned int value, float frequency) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency);
+inline void StatsdClient::histogram(const std::string& key,
+                                    const unsigned int value,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency, tags);
 }
 
-inline void StatsdClient::set(const std::string& key, const unsigned int sum, float frequency) const noexcept {
-    return send(key, sum, detail::METRIC_TYPE_SET, frequency);
+inline void StatsdClient::set(const std::string& key,
+                              const unsigned int sum,
+                              float frequency,
+                              const std::vector<std::string>& tags) const noexcept {
+    return send(key, sum, detail::METRIC_TYPE_SET, frequency, tags);
 }
 
 inline void StatsdClient::send(const std::string& key,
                                const int value,
                                const char* type,
-                               float frequency) const noexcept {
+                               float frequency,
+                               const std::vector<std::string>& tags) const noexcept {
     // Bail if we can't send anything anyway
     if (!m_sender->initialized()) {
         return;
@@ -215,6 +257,15 @@ inline void StatsdClient::send(const std::string& key,
     if (frequency < 1.f) {
         m_buffer.append("|@0.");
         m_buffer.append(std::to_string(static_cast<int>(frequency * 100)));
+    }
+
+    if (!tags.empty()) {
+        m_buffer.append("|#");
+        for (const auto& tag : tags) {
+            m_buffer.append(tag);
+            m_buffer.push_back(',');
+        }
+        m_buffer.pop_back();
     }
 
     // Send the message via the UDP sender

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -124,9 +124,19 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.tutu:1227|s");
 
         // Send a histogram of 13 values per time bin
-        client.histogram("rösti", 13);
+        client.histogram("dr.rösti", 13);
         throwOnError(client);
-        expected.emplace_back("sendRecv.rösti:13|h");
+        expected.emplace_back("sendRecv.dr.rösti:13|h");
+
+        // Gauge but with tags
+        client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
+        throwOnError(client);
+        expected.emplace_back("sendRecv.grabe:333|g|#liegt,im,weste");
+
+        // All the things
+        client.count("foo", -42, .9f, {"bar", "baz"});
+        throwOnError(client);
+        expected.emplace_back("sendRecv.foo:-42|c|@0.90|#bar,baz");
     }
 
     // Signal the mock server we are done

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -124,9 +124,9 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.tutu:1227|s");
 
         // Gauge but with tags
-        client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
+        client.gauge("dr.rösti.grabe", 333, 1.f, {"liegt", "im", "weste"});
         throwOnError(client);
-        expected.emplace_back("sendRecv.grabe:333|g|#liegt,im,weste");
+        expected.emplace_back("sendRecv.dr.rösti.grabe:333|g|#liegt,im,weste");
 
         // All the things
         client.count("foo", -42, .9f, {"bar", "baz"});

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -52,24 +52,24 @@ void testReconfigure() {
     StatsdServer server;
 
     StatsdClient client("localhost", 8125, "first.");
-    client.send("foo", 1, "c", 1.f);
+    client.increment("foo");
     if (server.receive() != "first.foo:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
     client.setConfig("localhost", 8125, "second");
-    client.send("bar", 1, "c", 1.f);
+    client.increment("bar");
     if (server.receive() != "second.bar:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
     client.setConfig("localhost", 8125, "");
-    client.send("third.baz", 1, "c", 1.f);
+    client.increment("third.baz");
     if (server.receive() != "third.baz:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
-    client.send("", 1, "c", 1.f);
+    client.increment("");
     if (server.receive() != ":1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
@@ -122,14 +122,19 @@ void testSendRecv(uint64_t batchSize) {
         throwOnError(client);
         expected.emplace_back("sendRecv.myTiming:2|ms|@0.10");
 
-        // Send a metric explicitly
-        client.send("tutu", 241, "c", 2.0f);
+        // Send a set with 1227 total uniques
+        client.set("tutu", 1227, 2.0f);
         throwOnError(client);
-        expected.emplace_back("sendRecv.tutu:241|c");
+        expected.emplace_back("sendRecv.tutu:1227|s");
+
+        // Send a histogram of 13 values per time bin
+        client.histogram("rösti", 13);
+        throwOnError(client);
+        expected.emplace_back("sendRecv.rösti:13|h");
     }
 
     // Signal the mock server we are done
-    client.send("DONE", 0, "ms");
+    client.timing("DONE", 0);
 
     // Wait for the server to stop
     server.join();

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -123,11 +123,6 @@ void testSendRecv(uint64_t batchSize) {
         throwOnError(client);
         expected.emplace_back("sendRecv.tutu:1227|s");
 
-        // Send a histogram of 13 values per time bin
-        client.histogram("dr.rösti", 13);
-        throwOnError(client);
-        expected.emplace_back("sendRecv.dr.rösti:13|h");
-
         // Gauge but with tags
         client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
         throwOnError(client);


### PR DESCRIPTION
As the title says! We also now protect against sending made up metric types by hiding the raw sending function.

Fixes #11 
Fixes #26 