### PR TITLE
More Control Over How/When to Send to the Daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,12 @@ The batchsize is the only parameter that cannot be changed for the time being.
 
 ### Batching
 
-The client supports batching of the metrics:
+The client supports batching of the metrics. The batch size parameter is the number of bytes to allow in each batch (UDP datagram payload) to be sent to the statsd process. This number is not a hard limit. If appending the current stat to the current batch (separated by the `'\n'` character) pushes the current batch over the batch size, that batch is enqueued (not sent) and a new batch is started. If batch size is 0, the default, then each stat is sent individually to the statsd process and no batches are enqueued.
 
-- the unit of the batching parameter is bytes,
-- it is optional and passing a 0 will result in an immediate send of any metrics,
+### Sending
 
-If set, the UDP sender will spawn a thread sending the metrics to the server every 1 second by aggregates. The aggregation logic is as follows:
+As previously mentioned, if batching is disabled (by setting the batch size to 0) then every stat is sent immediately in a blocking fashion. If batching is enabled (ie non-zero) then you may also set the send interval. The send interval controls the time, in milliseconds, to wait before flushing/sending the queued stats batches to the statsd process. When the send interval is non-zero a background thread is spawned which will do the flushing/sending at the configured send interval, in other words asynchronously. The queuing mechanism in this case is *not* lock-free. If batching is enabled but the send interval is set to zero then the queued batchs of stats will not be sent automatically by a background thread but must be sent manually via the `flush` method. The `flush` method is a blocking call.
 
-- if the last message has already reached the batching limit, add a new element in a message queue;
-- otherwise, append the message to the last one, separated by a `\n`.
 
 ### Frequency rate
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -87,13 +87,6 @@ public:
                 float frequency = 1.0f,
                 const std::vector<std::string>& tags = {}) const noexcept;
 
-    //! Records an arbitrary unit for a key, at a given frequency. An alias for timing
-    //! suited to use cases whose units do not involve time
-    void histogram(const std::string& key,
-                   const unsigned int value,
-                   float frequency = 1.0f,
-                   const std::vector<std::string>& tags = {}) const noexcept;
-
     //! Records a count of unique occurrences for a key, at a given frequency
     void set(const std::string& key,
              const unsigned int sum,
@@ -145,7 +138,6 @@ std::string sanitizePrefix(std::string prefix) {
 constexpr char METRIC_TYPE_COUNT[] = "c";
 constexpr char METRIC_TYPE_GUAGE[] = "g";
 constexpr char METRIC_TYPE_TIMING[] = "ms";
-constexpr char METRIC_TYPE_HISTOGRAM[] = "h";
 constexpr char METRIC_TYPE_SET[] = "s";
 }  // namespace detail
 
@@ -203,13 +195,6 @@ inline void StatsdClient::timing(const std::string& key,
                                  float frequency,
                                  const std::vector<std::string>& tags) const noexcept {
     return send(key, ms, detail::METRIC_TYPE_TIMING, frequency, tags);
-}
-
-inline void StatsdClient::histogram(const std::string& key,
-                                    const unsigned int value,
-                                    float frequency,
-                                    const std::vector<std::string>& tags) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency, tags);
 }
 
 inline void StatsdClient::set(const std::string& key,

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -24,11 +24,33 @@ namespace Statsd {
  * key, therefore you should neither append one to the prefix
  * nor prepend one to the key
  *
- * The sampling frequency can be input, as well as the
- * batching size. The latter is the optional limit in
- * number of bytes a batch of stats can be before it is
- * new states are added to a fresh batch. A value of 0
- * means batching is disabled.
+ * The sampling frequency is specified per call and uses a
+ * random number generator to determine whether or not the stat
+ * will be recorded this time or not.
+ *
+ * The top level configuration includes 2 optional parameters
+ * that determine how the stats are delivered to statsd. These
+ * parameters are the batching size and the send interval.
+ *
+ * The batching size controls the number of bytes to send
+ * in each UDP datagram to statsd. This is not a hard limit as
+ * we continue appending to a batch of stats until the limit
+ * has been reached or surpassed. When this occurs we add the
+ * batch to a queue and create a new batch to appended to. A
+ * value of 0 for the batching size will disable batching such
+ * that each stat will be sent to the daemon individually.
+ *
+ * The send interval controls the rate at which queued batches
+ * of stats will be sent to statsd. If batching is disabled,
+ * this value is ignored and each individual stat is sent to
+ * statsd immediately in a blocking fashion. If batching is
+ * enabled (ie. non-zero) then the send interval is the number
+ * of milliseconds to wait before flushing the queue of
+ * batched stats messages to the daemon. This is done in a non-
+ * blocking fashion via a background thread. If the send
+ * interval is 0 then the stats messages are appended to a
+ * queue until the caller manually flushes the queue via the
+ * flush method.
  *
  */
 class StatsdClient {
@@ -40,7 +62,8 @@ public:
     StatsdClient(const std::string& host,
                  const uint16_t port,
                  const std::string& prefix,
-                 const uint64_t batchsize = 0) noexcept;
+                 const uint64_t batchsize = 0,
+                 const uint64_t sendInterval = 1000) noexcept;
 
     StatsdClient(const StatsdClient&) = delete;
     StatsdClient& operator=(const StatsdClient&) = delete;
@@ -54,7 +77,8 @@ public:
     void setConfig(const std::string& host,
                    const uint16_t port,
                    const std::string& prefix,
-                   const uint64_t batchsize = 0) noexcept;
+                   const uint64_t batchsize = 0,
+                   const uint64_t sendInterval = 1000) noexcept;
 
     //! Returns the error message as an std::string
     const std::string& errorMessage() const noexcept;
@@ -95,6 +119,9 @@ public:
 
     //! Seed the RNG that controls sampling
     void seed(unsigned int seed = std::random_device()()) noexcept;
+
+    //! Flush any queued stats to the daemon
+    void flush() noexcept;
 
     //!@}
 
@@ -144,8 +171,9 @@ constexpr char METRIC_TYPE_SET[] = "s";
 inline StatsdClient::StatsdClient(const std::string& host,
                                   const uint16_t port,
                                   const std::string& prefix,
-                                  const uint64_t batchsize) noexcept
-    : m_prefix(detail::sanitizePrefix(prefix)), m_sender(new UDPSender{host, port, batchsize}) {
+                                  const uint64_t batchsize,
+                                  const uint64_t sendInterval) noexcept
+    : m_prefix(detail::sanitizePrefix(prefix)), m_sender(new UDPSender{host, port, batchsize, sendInterval}) {
     // Initialize the random generator to be used for sampling
     seed();
     // Avoid re-allocations by reserving a generous buffer
@@ -155,9 +183,10 @@ inline StatsdClient::StatsdClient(const std::string& host,
 inline void StatsdClient::setConfig(const std::string& host,
                                     const uint16_t port,
                                     const std::string& prefix,
-                                    const uint64_t batchsize) noexcept {
+                                    const uint64_t batchsize,
+                                    const uint64_t sendInterval) noexcept {
     m_prefix = detail::sanitizePrefix(prefix);
-    m_sender.reset(new UDPSender(host, port, batchsize));
+    m_sender.reset(new UDPSender(host, port, batchsize, sendInterval));
 }
 
 inline const std::string& StatsdClient::errorMessage() const noexcept {
@@ -259,6 +288,10 @@ inline void StatsdClient::send(const std::string& key,
 
 inline void StatsdClient::seed(unsigned int seed) noexcept {
     m_randomEngine.seed(seed);
+}
+
+inline void StatsdClient::flush() noexcept {
+    m_sender->flush();
 }
 
 }  // namespace Statsd

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <vector>
 
 namespace Statsd {
 
@@ -59,26 +60,45 @@ public:
     const std::string& errorMessage() const noexcept;
 
     //! Increments the key, at a given frequency rate
-    void increment(const std::string& key, float frequency = 1.0f) const noexcept;
+    void increment(const std::string& key,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Increments the key, at a given frequency rate
-    void decrement(const std::string& key, float frequency = 1.0f) const noexcept;
+    void decrement(const std::string& key,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Adjusts the specified key by a given delta, at a given frequency rate
-    void count(const std::string& key, const int delta, float frequency = 1.0f) const noexcept;
+    void count(const std::string& key,
+               const int delta,
+               float frequency = 1.0f,
+               const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a gauge for the key, with a given value, at a given frequency rate
-    void gauge(const std::string& key, const unsigned int value, float frequency = 1.0f) const noexcept;
+    void gauge(const std::string& key,
+               const unsigned int value,
+               float frequency = 1.0f,
+               const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a timing for a key, at a given frequency
-    void timing(const std::string& key, const unsigned int ms, float frequency = 1.0f) const noexcept;
+    void timing(const std::string& key,
+                const unsigned int ms,
+                float frequency = 1.0f,
+                const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records an arbitrary unit for a key, at a given frequency. An alias for timing
     //! suited to use cases whose units do not involve time
-    void histogram(const std::string& key, const unsigned int value, float frequency = 1.0f) const noexcept;
+    void histogram(const std::string& key,
+                   const unsigned int value,
+                   float frequency = 1.0f,
+                   const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Records a count of unique occurrences for a key, at a given frequency
-    void set(const std::string& key, const unsigned int sum, float frequency = 1.0f) const noexcept;
+    void set(const std::string& key,
+             const unsigned int sum,
+             float frequency = 1.0f,
+             const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Seed the RNG that controls sampling
     void seed(unsigned int seed = std::random_device()()) noexcept;
@@ -90,7 +110,11 @@ private:
     // @{
 
     //! Send a value for a key, according to its type, at a given frequency
-    void send(const std::string& key, const int value, const char* type, float frequency = 1.0f) const noexcept;
+    void send(const std::string& key,
+              const int value,
+              const char* type,
+              float frequency,
+              const std::vector<std::string>& tags) const noexcept;
 
     //!@}
 
@@ -148,40 +172,58 @@ inline const std::string& StatsdClient::errorMessage() const noexcept {
     return m_sender->errorMessage();
 }
 
-inline void StatsdClient::decrement(const std::string& key, float frequency) const noexcept {
-    return count(key, -1, frequency);
+inline void StatsdClient::decrement(const std::string& key,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return count(key, -1, frequency, tags);
 }
 
-inline void StatsdClient::increment(const std::string& key, float frequency) const noexcept {
-    return count(key, 1, frequency);
+inline void StatsdClient::increment(const std::string& key,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return count(key, 1, frequency, tags);
 }
 
-inline void StatsdClient::count(const std::string& key, const int delta, float frequency) const noexcept {
-    return send(key, delta, detail::METRIC_TYPE_COUNT, frequency);
+inline void StatsdClient::count(const std::string& key,
+                                const int delta,
+                                float frequency,
+                                const std::vector<std::string>& tags) const noexcept {
+    return send(key, delta, detail::METRIC_TYPE_COUNT, frequency, tags);
 }
 
 inline void StatsdClient::gauge(const std::string& key,
                                 const unsigned int value,
-                                const float frequency) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_GUAGE, frequency);
+                                const float frequency,
+                                const std::vector<std::string>& tags) const noexcept {
+    return send(key, value, detail::METRIC_TYPE_GUAGE, frequency, tags);
 }
 
-inline void StatsdClient::timing(const std::string& key, const unsigned int ms, float frequency) const noexcept {
-    return send(key, ms, detail::METRIC_TYPE_TIMING, frequency);
+inline void StatsdClient::timing(const std::string& key,
+                                 const unsigned int ms,
+                                 float frequency,
+                                 const std::vector<std::string>& tags) const noexcept {
+    return send(key, ms, detail::METRIC_TYPE_TIMING, frequency, tags);
 }
 
-inline void StatsdClient::histogram(const std::string& key, const unsigned int value, float frequency) const noexcept {
-    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency);
+inline void StatsdClient::histogram(const std::string& key,
+                                    const unsigned int value,
+                                    float frequency,
+                                    const std::vector<std::string>& tags) const noexcept {
+    return send(key, value, detail::METRIC_TYPE_HISTOGRAM, frequency, tags);
 }
 
-inline void StatsdClient::set(const std::string& key, const unsigned int sum, float frequency) const noexcept {
-    return send(key, sum, detail::METRIC_TYPE_SET, frequency);
+inline void StatsdClient::set(const std::string& key,
+                              const unsigned int sum,
+                              float frequency,
+                              const std::vector<std::string>& tags) const noexcept {
+    return send(key, sum, detail::METRIC_TYPE_SET, frequency, tags);
 }
 
 inline void StatsdClient::send(const std::string& key,
                                const int value,
                                const char* type,
-                               float frequency) const noexcept {
+                               float frequency,
+                               const std::vector<std::string>& tags) const noexcept {
     // Bail if we can't send anything anyway
     if (!m_sender->initialized()) {
         return;
@@ -215,6 +257,15 @@ inline void StatsdClient::send(const std::string& key,
     if (frequency < 1.f) {
         m_buffer.append("|@0.");
         m_buffer.append(std::to_string(static_cast<int>(frequency * 100)));
+    }
+
+    if (!tags.empty()) {
+        m_buffer.append("|#");
+        for (const auto& tag : tags) {
+            m_buffer.append(tag);
+            m_buffer.push_back(',');
+        }
+        m_buffer.pop_back();
     }
 
     // Send the message via the UDP sender

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -28,7 +28,7 @@ public:
     //!@{
 
     //! Constructor
-    UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize = 0) noexcept;
+    UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize, const uint64_t sendInterval) noexcept;
 
     //! Destructor
     ~UDPSender();
@@ -38,7 +38,7 @@ public:
     //!@name Methods
     //!@{
 
-    //! Send a message
+    //! Send or enqueue a message
     void send(const std::string& message) noexcept;
 
     //! Returns the error message as a string
@@ -46,6 +46,9 @@ public:
 
     //! Returns true if the sender is initialized
     bool initialized() const noexcept;
+
+    //! Flushes any queued messages
+    void flush() noexcept;
 
     //!@}
 
@@ -93,14 +96,14 @@ private:
     // @name Batching info
     // @{
 
-    //! Shall the sender use batching?
-    bool m_batching{false};
-
     //! The batching size
     uint64_t m_batchsize;
 
+    //! The sending frequency in milliseconds
+    uint64_t m_sendInterval;
+
     //! The queue batching the messages
-    mutable std::deque<std::string> m_batchingMessageQueue;
+    std::deque<std::string> m_batchingMessageQueue;
 
     //! The mutex used for batching
     std::mutex m_batchingMutex;
@@ -117,24 +120,17 @@ private:
     static constexpr int k_invalidFd{-1};
 };
 
-inline UDPSender::UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize) noexcept
-    : m_host(host), m_port(port) {
+inline UDPSender::UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize, const uint64_t sendInterval) noexcept
+    : m_host(host), m_port(port), m_batchsize(batchsize), m_sendInterval(sendInterval) {
     // Initialize the socket
     if (!initialize()) {
         return;
     }
 
     // If batching is on, use a dedicated thread to send after the wait time is reached
-    if (batchsize != 0) {
-        // Thread' sleep duration between batches
-        // TODO: allow to input this
-        constexpr unsigned int batchingWait{1000U};
-
-        m_batching = true;
-        m_batchsize = batchsize;
-
+    if (m_batchsize != 0 && m_sendInterval > 0) {
         // Define the batching thread
-        m_batchingThread = std::thread([this, batchingWait] {
+        m_batchingThread = std::thread([this] {
             // TODO: this will drop unsent stats, should we send all the unsent stats before we exit?
             while (!m_mustExit.load(std::memory_order_acq_rel)) {
                 std::deque<std::string> stagedMessageQueue;
@@ -150,7 +146,7 @@ inline UDPSender::UDPSender(const std::string& host, const uint16_t port, const 
                 }
 
                 // Wait before sending the next batch
-                std::this_thread::sleep_for(std::chrono::milliseconds(batchingWait));
+                std::this_thread::sleep_for(std::chrono::milliseconds(m_sendInterval));
             }
         });
     }
@@ -161,27 +157,32 @@ inline UDPSender::~UDPSender() {
         return;
     }
 
-    if (m_batching) {
+    // If we're running a background thread tell it to stop
+    if (m_batchingThread.joinable()) {
         m_mustExit.store(true, std::memory_order_acq_rel);
         m_batchingThread.join();
     }
 
+    // Cleanup the socket
     close(m_socket);
 }
 
 inline void UDPSender::send(const std::string& message) noexcept {
     m_errorMessage.clear();
+
     // If batching is on, accumulate messages in the queue
-    if (m_batching) {
+    if (m_batchsize > 0) {
         queueMessage(message);
         return;
     }
 
+    // Or send it right now
     sendToDaemon(message);
 }
 
 inline void UDPSender::queueMessage(const std::string& message) noexcept {
-    std::unique_lock<std::mutex> batchingLock(m_batchingMutex);
+    // We aquire a lock but only if we actually need to (ie there is a thread also accessing the queue)
+    auto batchingLock = m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
     // Either we don't have a place to batch our message or we exceeded the batch size, so make a new batch
     if (m_batchingMessageQueue.empty() || m_batchingMessageQueue.back().length() > m_batchsize) {
         m_batchingMessageQueue.emplace_back();
@@ -253,6 +254,16 @@ inline void UDPSender::sendToDaemon(const std::string& message) noexcept {
 
 inline bool UDPSender::initialized() const noexcept {
     return m_socket != k_invalidFd;
+}
+
+inline void UDPSender::flush() noexcept {
+    // We aquire a lock but only if we actually need to (ie there is a thread also accessing the queue)
+    auto batchingLock = m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
+    // Flush the queue
+    while (!m_batchingMessageQueue.empty()) {
+        sendToDaemon(m_batchingMessageQueue.front());
+        m_batchingMessageQueue.pop_front();
+    }
 }
 
 }  // namespace Statsd

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -28,7 +28,10 @@ public:
     //!@{
 
     //! Constructor
-    UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize, const uint64_t sendInterval) noexcept;
+    UDPSender(const std::string& host,
+              const uint16_t port,
+              const uint64_t batchsize,
+              const uint64_t sendInterval) noexcept;
 
     //! Destructor
     ~UDPSender();
@@ -120,7 +123,10 @@ private:
     static constexpr int k_invalidFd{-1};
 };
 
-inline UDPSender::UDPSender(const std::string& host, const uint16_t port, const uint64_t batchsize, const uint64_t sendInterval) noexcept
+inline UDPSender::UDPSender(const std::string& host,
+                            const uint16_t port,
+                            const uint64_t batchsize,
+                            const uint64_t sendInterval) noexcept
     : m_host(host), m_port(port), m_batchsize(batchsize), m_sendInterval(sendInterval) {
     // Initialize the socket
     if (!initialize()) {
@@ -182,7 +188,8 @@ inline void UDPSender::send(const std::string& message) noexcept {
 
 inline void UDPSender::queueMessage(const std::string& message) noexcept {
     // We aquire a lock but only if we actually need to (ie there is a thread also accessing the queue)
-    auto batchingLock = m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
+    auto batchingLock =
+        m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
     // Either we don't have a place to batch our message or we exceeded the batch size, so make a new batch
     if (m_batchingMessageQueue.empty() || m_batchingMessageQueue.back().length() > m_batchsize) {
         m_batchingMessageQueue.emplace_back();
@@ -258,7 +265,8 @@ inline bool UDPSender::initialized() const noexcept {
 
 inline void UDPSender::flush() noexcept {
     // We aquire a lock but only if we actually need to (ie there is a thread also accessing the queue)
-    auto batchingLock = m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
+    auto batchingLock =
+        m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
     // Flush the queue
     while (!m_batchingMessageQueue.empty()) {
         sendToDaemon(m_batchingMessageQueue.front());

--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -187,7 +187,7 @@ inline void UDPSender::send(const std::string& message) noexcept {
 }
 
 inline void UDPSender::queueMessage(const std::string& message) noexcept {
-    // We aquire a lock but only if we actually need to (ie there is a thread also accessing the queue)
+    // We aquire a lock but only if we actually need to (i.e. there is a thread also accessing the queue)
     auto batchingLock =
         m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
     // Either we don't have a place to batch our message or we exceeded the batch size, so make a new batch

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -124,9 +124,19 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.tutu:1227|s");
 
         // Send a histogram of 13 values per time bin
-        client.histogram("rösti", 13);
+        client.histogram("dr.rösti", 13);
         throwOnError(client);
-        expected.emplace_back("sendRecv.rösti:13|h");
+        expected.emplace_back("sendRecv.dr.rösti:13|h");
+
+        // Gauge but with tags
+        client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
+        throwOnError(client);
+        expected.emplace_back("sendRecv.grabe:333|g|#liegt,im,weste");
+
+        // All the things
+        client.count("foo", -42, .9f, {"bar", "baz"});
+        throwOnError(client);
+        expected.emplace_back("sendRecv.foo:-42|c|@0.90|#bar,baz");
     }
 
     // Signal the mock server we are done

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -74,13 +74,13 @@ void testReconfigure() {
     //  batches being dropped vs sent on reconfiguring
 }
 
-void testSendRecv(uint64_t batchSize) {
+void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
     StatsdServer mock_server;
     std::vector<std::string> messages, expected;
     std::thread server(mock, std::ref(mock_server), std::ref(messages));
 
     // Set a new config that has the client send messages to a proper address that can be resolved
-    StatsdClient client("localhost", 8125, "sendRecv.", batchSize);
+    StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval);
     throwOnError(client);
 
     // TODO: I forget if we need to wait for the server to be ready here before sending the first stats
@@ -137,6 +137,11 @@ void testSendRecv(uint64_t batchSize) {
     // Signal the mock server we are done
     client.timing("DONE", 0);
 
+    // If manual flushing do it now
+    if (sendInterval == 0) {
+        client.flush();
+    }
+
     // Wait for the server to stop
     server.join();
 
@@ -162,9 +167,11 @@ int main() {
     // reconfiguring how you are sending
     testReconfigure();
     // no batching
-    testSendRecv(0);
+    testSendRecv(0, 0);
     // background batching
-    testSendRecv(4);
+    testSendRecv(32, 1000);
+    // manual flushing of batches
+    testSendRecv(16, 0);
 
     return EXIT_SUCCESS;
 }

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -124,9 +124,9 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.tutu:1227|s");
 
         // Gauge but with tags
-        client.gauge("dr.rösti.grabe", 333, 1.f, {"liegt", "im", "weste"});
+        client.gauge("dr.röstigrabe", 333, 1.f, {"liegt", "im", "weste"});
         throwOnError(client);
-        expected.emplace_back("sendRecv.dr.rösti.grabe:333|g|#liegt,im,weste");
+        expected.emplace_back("sendRecv.dr.röstigrabe:333|g|#liegt,im,weste");
 
         // All the things
         client.count("foo", -42, .9f, {"bar", "baz"});

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -124,9 +124,9 @@ void testSendRecv(uint64_t batchSize) {
         expected.emplace_back("sendRecv.tutu:1227|s");
 
         // Gauge but with tags
-        client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
+        client.gauge("dr.rösti.grabe", 333, 1.f, {"liegt", "im", "weste"});
         throwOnError(client);
-        expected.emplace_back("sendRecv.grabe:333|g|#liegt,im,weste");
+        expected.emplace_back("sendRecv.dr.rösti.grabe:333|g|#liegt,im,weste");
 
         // All the things
         client.count("foo", -42, .9f, {"bar", "baz"});

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -52,24 +52,24 @@ void testReconfigure() {
     StatsdServer server;
 
     StatsdClient client("localhost", 8125, "first.");
-    client.send("foo", 1, "c", 1.f);
+    client.increment("foo");
     if (server.receive() != "first.foo:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
     client.setConfig("localhost", 8125, "second");
-    client.send("bar", 1, "c", 1.f);
+    client.increment("bar");
     if (server.receive() != "second.bar:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
     client.setConfig("localhost", 8125, "");
-    client.send("third.baz", 1, "c", 1.f);
+    client.increment("third.baz");
     if (server.receive() != "third.baz:1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
 
-    client.send("", 1, "c", 1.f);
+    client.increment("");
     if (server.receive() != ":1|c") {
         throw std::runtime_error("Incorrect stat received");
     }
@@ -122,14 +122,19 @@ void testSendRecv(uint64_t batchSize) {
         throwOnError(client);
         expected.emplace_back("sendRecv.myTiming:2|ms|@0.10");
 
-        // Send a metric explicitly
-        client.send("tutu", 241, "c", 2.0f);
+        // Send a set with 1227 total uniques
+        client.set("tutu", 1227, 2.0f);
         throwOnError(client);
-        expected.emplace_back("sendRecv.tutu:241|c");
+        expected.emplace_back("sendRecv.tutu:1227|s");
+
+        // Send a histogram of 13 values per time bin
+        client.histogram("rösti", 13);
+        throwOnError(client);
+        expected.emplace_back("sendRecv.rösti:13|h");
     }
 
     // Signal the mock server we are done
-    client.send("DONE", 0, "ms");
+    client.timing("DONE", 0);
 
     // Wait for the server to stop
     server.join();

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -123,11 +123,6 @@ void testSendRecv(uint64_t batchSize) {
         throwOnError(client);
         expected.emplace_back("sendRecv.tutu:1227|s");
 
-        // Send a histogram of 13 values per time bin
-        client.histogram("dr.rösti", 13);
-        throwOnError(client);
-        expected.emplace_back("sendRecv.dr.rösti:13|h");
-
         // Gauge but with tags
         client.gauge("grabe", 333, 1.f, {"liegt", "im", "weste"});
         throwOnError(client);


### PR DESCRIPTION
fixes #20 

The brief idea here is that we would like more explicit control over how and when to send a batch of stats to the statsd process. This PR adds one more control, specifically the time interval at which stats batches are sent. This API change is not breaking in terms of a major version as the default functionality is maintained but a new parameter is added to the configuration which allows this finer grained control. In addition to this finer control we also allow manual flushing (ie on-demand flushing of batches of stats in the queue). This allows a calling application to queue/batch stats as much as they want and then decide on thier own when is a good time to send those to statsd.

I've updated the documentation in the code to spell this out but this could probably also be done in the README, ~so I'll add that too~ I've added that.

~I'll put this in draft for now as I didnt write the unit tests yet. Once I have the tests and the README updated I'll take it out of draft~ this has all been done.

@vthiery let me know what your opinion is on this extra level of control. I also thought maybe I should add an accessor to return the queue depth as it might inform the callers decision about when to flush the stats if they are doing it manually.