### PR TITLE
breakfix for ODR

### DIFF
--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -153,7 +153,7 @@ private:
 };
 
 namespace detail {
-std::string sanitizePrefix(std::string prefix) {
+inline std::string sanitizePrefix(std::string prefix) {
     // For convenience we provide the dot when generating the stat message
     if (!prefix.empty() && prefix.back() == '.') {
         prefix.pop_back();


### PR DESCRIPTION
if you include this header in multiple compilation units you will violate the ODR and your compiler will tell you that its multiply defined. we inline it to fix this like the rest of the library