### PR TITLE
Allow float gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ A simple example of how to use the client:
 using namespace Statsd;
 
 int main() {
-    // Define the client on localhost, with port 8080, using a prefix and a batching size of 20 bytes
-    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20 };
+    // Define the client on localhost, with port 8080,
+    // using a prefix,
+    // a batching size of 20 bytes,
+    // and three points of precision for floating point gauge values
+    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20, 3 };
 
     // Increment the metric "coco"
     client.increment("coco");
@@ -110,13 +113,16 @@ using namespace Statsd;
 
 int main()
 {
-    // Define the client on localhost, with port 8080, using a prefix and a batching size of 20 bytes
-    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20 };
+    // Define the client on localhost, with port 8080,
+    // using a prefix,
+    // a batching size of 20 bytes,
+    // and three points of precision for floating point gauge values
+    StatsdClient client{ "127.0.0.1", 8080, "myPrefix", 20, 3 };
 
     client.increment("coco");
 
-    // Set a new configuration, using a different port and a different prefix
-    client.setConfig("127.0.0.1", 8000, "anotherPrefix");
+    // Set a new configuration, using a different port, a different prefix, and more gauge precision
+    client.setConfig("127.0.0.1", 8000, "anotherPrefix", 6);
 
     client.decrement("kiki");
 }

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -82,7 +82,7 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
     std::thread server(mock, std::ref(mock_server), std::ref(messages));
 
     // Set a new config that has the client send messages to a proper address that can be resolved
-    StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval);
+    StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval, 3);
     throwOnError(client);
 
     // TODO: I forget if we need to wait for the server to be ready here before sending the first stats
@@ -113,6 +113,11 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
         client.gauge("titi", 3);
         throwOnError(client);
         expected.emplace_back("sendRecv.titi:3|g");
+
+        // Record a gauge "titifloat" to -123.456789 with precision 3
+        client.gauge("titifloat", -123.456789);
+        throwOnError(client);
+        expected.emplace_back("sendRecv.titifloat:-123.457|g");
 
         // Record a timing of 2ms for "myTiming"
         client.seed(19);


### PR DESCRIPTION
@vthiery Currently only int values can be given for gauges due to the functions definitions.  I'd like to be able to send floats.