### PR TITLE
feat: support custom metric types

### DIFF
--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -122,6 +122,14 @@ public:
              float frequency = 1.0f,
              const std::vector<std::string>& tags = {}) const noexcept;
 
+    //! Records a custom metric type for the key, with a given value, at a given frequency
+    template <typename T>
+    void custom(const std::string& key,
+                const T value,
+                const char* type,
+                float frequency = 1.0f,
+                const std::vector<std::string>& tags = {}) const noexcept;
+
     //! Seed the RNG that controls sampling
     void seed(unsigned int seed = std::random_device()()) noexcept;
 
@@ -246,6 +254,15 @@ inline void StatsdClient::set(const std::string& key,
                               float frequency,
                               const std::vector<std::string>& tags) const noexcept {
     send(key, sum, detail::METRIC_TYPE_SET, frequency, tags);
+}
+
+template <typename T>
+inline void StatsdClient::custom(const std::string& key,
+                                 const T value,
+                                 const char* type,
+                                 const float frequency,
+                                 const std::vector<std::string>& tags) const noexcept {
+    send(key, value, type, frequency, tags);
 }
 
 template <typename T>

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -139,6 +139,11 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
         client.count("foo", -42, .9f, {"bar", "baz"});
         throwOnError(client);
         expected.emplace_back("sendRecv.foo:-42|c|@0.90|#bar,baz");
+
+        // Custom metric type should pass through all params
+        client.custom("custom_metric_type", 5678, "cust", .95f, {"tag1", "tag2"});
+        throwOnError(client);
+        expected.emplace_back("sendRecv.custom_metric_type:5678|cust|@0.95|#tag1,tag2");
     }
 
     // Signal the mock server we are done


### PR DESCRIPTION
Other statsd backends (e.g. Datadog, netdata) support metric types beyond
those supported by the original Etsy statsd daemon.  For example:

* Histograms (type "h") which are like Timers, but with different units.

* Dictionaries (type "d") which are like Sets but also record a count for
  each unique value.

Since these are non-standard, add a `custom()` method, where the metric
type is passed in by the caller, assuming that they know the capabilities
of the backend they are using.