### PR TITLE
fix: include incoming message size when checking against batch size

### DIFF
--- a/include/cpp-statsd-client/UDPSender.hpp
+++ b/include/cpp-statsd-client/UDPSender.hpp
@@ -246,8 +246,8 @@ inline void UDPSender::queueMessage(const std::string& message) noexcept {
     // We aquire a lock but only if we actually need to (i.e. there is a thread also accessing the queue)
     auto batchingLock =
         m_batchingThread.joinable() ? std::unique_lock<std::mutex>(m_batchingMutex) : std::unique_lock<std::mutex>();
-    // Either we don't have a place to batch our message or we exceeded the batch size, so make a new batch
-    if (m_batchingMessageQueue.empty() || m_batchingMessageQueue.back().length() > m_batchsize) {
+    // Either we don't have a place to batch our message or we are about to exceed the batch size, so make a new batch
+    if (m_batchingMessageQueue.empty() || m_batchingMessageQueue.back().size() + message.size() > m_batchsize) {
         m_batchingMessageQueue.emplace_back();
         m_batchingMessageQueue.back().reserve(m_batchsize + 256);
     }  // When there is already a batch open we need a separator when its not empty


### PR DESCRIPTION
## Expected behavior

* Create `StatsdClient` with `batchsize`
* Push a few messages that are under `batchsize`, remains in same batch
* Push a message that would go over `batchsize` if appended,  gets put into a **new** batch
* Trigger flush, two batches are created, both **under** `batchsize`

## Actual behavior

* Create `StatsdClient` with `batchsize`
* Push a few messages that are under `batchsize`, remains in same batch
* Push a message that would go over `batchsize` if appended,  gets put into **same** batch
* Flush triggered, one batch is created **exceeding** `batchsize`

## Steps to reproduce

* Revert e3bffa355c069b89968877adc8d3933cf27d83d9 and run tests, a hyphen (`-`) is used to indicate a batch