### PR TITLE
further threadsafety hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Linux status](https://img.shields.io/github/workflow/status/vthiery/cpp-statsd-client/Linux?label=Linux&style=for-the-badge)](https://github.com/vthiery/cpp-statsd-client/actions/workflows/linux.yml?query=branch%3Amaster++)
 [![Windows status](https://img.shields.io/github/workflow/status/vthiery/cpp-statsd-client/Windows?label=Windows&style=for-the-badge)](https://github.com/vthiery/cpp-statsd-client/actions/workflows/windows.yml?query=branch%3Amaster++)
 
-A header-only StatsD client implemented in C++.
+A thread-safe header-only StatsD client implemented in C++.
 The client allows:
 
 - batching,

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -270,7 +270,7 @@ inline void StatsdClient::send(const std::string& key,
     constexpr float epsilon{0.0001f};
     const bool isFrequencyOne = std::fabs(frequency - 1.0f) < epsilon;
     const bool isFrequencyZero = std::fabs(frequency) < epsilon;
-    if (isFrequencyZero || (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(rng())))) {
+    if (isFrequencyZero || (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(detail::rng())))) {
         return;
     }
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -162,7 +162,7 @@ inline std::string sanitizePrefix(std::string prefix) {
     return prefix;
 }
 
-std::mt19937& rng(unsigned int seed = 0) {
+inline std::mt19937& rng(unsigned int seed = 0) {
     static thread_local std::mt19937 twister(seed);
     return twister;
 }
@@ -186,17 +186,6 @@ inline StatsdClient::StatsdClient(const std::string& host,
       m_gaugePrecision(gaugePrecision) {
     // Initialize the random generator to be used for sampling
     detail::rng(seed);
-}
-
-inline void StatsdClient::setConfig(const std::string& host,
-                                    const uint16_t port,
-                                    const std::string& prefix,
-                                    const uint64_t batchsize,
-                                    const uint64_t sendInterval,
-                                    const int gaugePrecision) noexcept {
-    m_prefix = detail::sanitizePrefix(prefix);
-    m_sender.reset(new UDPSender(host, port, batchsize, sendInterval));
-    m_gaugePrecision = gaugePrecision;
 }
 
 inline const std::string& StatsdClient::errorMessage() const noexcept {

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -124,7 +124,7 @@ public:
                 const std::vector<std::string>& tags = {}) const noexcept;
 
     //! Flush any queued stats to the daemon
-    void flush() noexcept;
+    void flush() const noexcept;
 
     //!@}
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -81,7 +81,6 @@ constexpr char METRIC_TYPE_SET[] = "s";
  */
 class StatsdClient {
 public:
-
     //! A functor that returns a value between 0 and 1 used
     //! to determine whether a given message is sampled.
     using FrequencyFunc = std::function<float()>;
@@ -96,8 +95,7 @@ public:
                  const uint64_t batchsize = 0,
                  const uint64_t sendInterval = 1000,
                  const int gaugePrecision = 4,
-                 FrequencyFunc frequencyFunc =
-                     std::bind(detail::rand, std::random_device()())) noexcept;
+                 FrequencyFunc frequencyFunc = std::bind(detail::rand, std::random_device()())) noexcept;
 
     StatsdClient(const StatsdClient&) = delete;
     StatsdClient& operator=(const StatsdClient&) = delete;
@@ -191,11 +189,11 @@ inline StatsdClient::StatsdClient(const std::string& host,
                                   const uint64_t batchsize,
                                   const uint64_t sendInterval,
                                   const int gaugePrecision,
-                                  FrequencyFunc  frequencyFunc) noexcept
+                                  FrequencyFunc frequencyFunc) noexcept
     : m_prefix(detail::sanitizePrefix(prefix)),
       m_sender(new UDPSender{host, port, batchsize, sendInterval}),
-      m_gaugePrecision(gaugePrecision), m_frequencyFunc(std::move(frequencyFunc)) {
-}
+      m_gaugePrecision(gaugePrecision),
+      m_frequencyFunc(std::move(frequencyFunc)) {}
 
 inline const std::string& StatsdClient::errorMessage() const noexcept {
     return m_sender->errorMessage();
@@ -268,8 +266,7 @@ inline void StatsdClient::send(const std::string& key,
     constexpr float epsilon{0.0001f};
     const bool isFrequencyOne = std::fabs(frequency - 1.0f) < epsilon;
     const bool isFrequencyZero = std::fabs(frequency) < epsilon;
-    if (isFrequencyZero ||
-        (!isFrequencyOne && (frequency < m_frequencyFunc()))) {
+    if (isFrequencyZero || (!isFrequencyOne && (frequency < m_frequencyFunc()))) {
         return;
     }
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -96,7 +96,7 @@ public:
                  const uint64_t batchsize = 0,
                  const uint64_t sendInterval = 1000,
                  const int gaugePrecision = 4,
-                 FrequencyFunc  frequencyFunc =
+                 FrequencyFunc frequencyFunc =
                      std::bind(detail::rand, std::random_device()())) noexcept;
 
     StatsdClient(const StatsdClient&) = delete;

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -270,7 +270,8 @@ inline void StatsdClient::send(const std::string& key,
     constexpr float epsilon{0.0001f};
     const bool isFrequencyOne = std::fabs(frequency - 1.0f) < epsilon;
     const bool isFrequencyZero = std::fabs(frequency) < epsilon;
-    if (isFrequencyZero || (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(detail::rng())))) {
+    if (isFrequencyZero ||
+        (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(detail::rng())))) {
         return;
     }
 

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -185,7 +185,7 @@ inline StatsdClient::StatsdClient(const std::string& host,
       m_sender(new UDPSender{host, port, batchsize, sendInterval}),
       m_gaugePrecision(gaugePrecision) {
     // Initialize the random generator to be used for sampling
-    rng(seed);
+    detail::rng(seed);
 }
 
 inline void StatsdClient::setConfig(const std::string& host,

--- a/include/cpp-statsd-client/StatsdClient.hpp
+++ b/include/cpp-statsd-client/StatsdClient.hpp
@@ -162,7 +162,7 @@ inline std::string sanitizePrefix(std::string prefix) {
     return prefix;
 }
 
-std::mt19937& rng(unsigned int seed = 0){
+std::mt19937& rng(unsigned int seed = 0) {
     static thread_local std::mt19937 twister(seed);
     return twister;
 }
@@ -179,7 +179,7 @@ inline StatsdClient::StatsdClient(const std::string& host,
                                   const std::string& prefix,
                                   const uint64_t batchsize,
                                   const uint64_t sendInterval,
-                                  const int gaugePrecision
+                                  const int gaugePrecision,
                                   const unsigned int seed) noexcept
     : m_prefix(detail::sanitizePrefix(prefix)),
       m_sender(new UDPSender{host, port, batchsize, sendInterval}),
@@ -270,8 +270,7 @@ inline void StatsdClient::send(const std::string& key,
     constexpr float epsilon{0.0001f};
     const bool isFrequencyOne = std::fabs(frequency - 1.0f) < epsilon;
     const bool isFrequencyZero = std::fabs(frequency) < epsilon;
-    if (isFrequencyZero ||
-        (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(rng())))) {
+    if (isFrequencyZero || (!isFrequencyOne && (frequency < std::uniform_real_distribution<float>(0.f, 1.f)(rng())))) {
         return;
     }
 

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -153,8 +153,6 @@ int main() {
 
     // general things that should be errors
     testErrorConditions();
-    // reconfiguring how you are sending
-    testReconfigure();
     // no batching
     testSendRecv(0, 0);
     // background batching

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -60,7 +60,7 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
 
     std::mt19937 twister(std::random_device{}());
     std::uniform_real_distribution<float> dist(0.f, 1.f);
-    auto rand = [&]()->float{return dist(twister);};
+    auto rand = [&]() -> float { return dist(twister); };
 
     // Set a new config that has the client send messages to a proper address that can be resolved
     StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval, 3, rand);
@@ -146,12 +146,14 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
                 break;
             }
             if (messages[i] != expected[i]) {
-                std::cerr << "Mismatch at index " << i << ": expected '" << expected[i] << "', got '" << messages[i] << "'" << std::endl;
+                std::cerr << "Mismatch at index " << i << ": expected '" << expected[i] << "', got '" << messages[i]
+                          << "'" << std::endl;
                 break;
             }
         }
         if (messages.size() > expected.size()) {
-            std::cerr << "Got more messages than expected, got " << messages.size() << ", expected " << expected.size() << std::endl;
+            std::cerr << "Got more messages than expected, got " << messages.size() << ", expected " << expected.size()
+                      << std::endl;
         }
         throw std::runtime_error("Unexpected stats");
     }

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -53,29 +53,6 @@ void testErrorConditions() {
     throwOnError(client, false, "Should not be able to resolve a ridiculous ip");
 }
 
-void testReconfigure() {
-    StatsdServer server;
-    throwOnError(server);
-
-    StatsdClient client("localhost", 8125, "first.");
-    client.increment("foo");
-    throwOnWrongMessage(server, "first.foo:1|c");
-
-    client.setConfig("localhost", 8125, "second");
-    client.increment("bar");
-    throwOnWrongMessage(server, "second.bar:1|c");
-
-    client.setConfig("localhost", 8125, "");
-    client.increment("third.baz");
-    throwOnWrongMessage(server, "third.baz:1|c");
-
-    client.increment("");
-    throwOnWrongMessage(server, ":1|c");
-
-    // TODO: test what happens with the batching after resolving the question about incomplete
-    //  batches being dropped vs sent on reconfiguring
-}
-
 void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
     StatsdServer mock_server;
     std::vector<std::string> messages, expected;

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -70,7 +70,7 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
     //  is there a race condition where the client sending before the server binds would drop that clients message
 
     for (int i = 0; i < 3; ++i) {
-                // Increment "coco"
+        // Increment "coco"
         client.increment("coco");
         throwOnError(client);
         expected.emplace_back("sendRecv.coco:1|c");

--- a/tests/testStatsdClient.cpp
+++ b/tests/testStatsdClient.cpp
@@ -59,7 +59,7 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
     std::thread server(mock, std::ref(mock_server), std::ref(messages));
 
     // Set a new config that has the client send messages to a proper address that can be resolved
-    StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval, 3);
+    StatsdClient client("localhost", 8125, "sendRecv.", batchSize, sendInterval, 3, 19); // this seed works for the testing below
     throwOnError(client);
 
     // TODO: I forget if we need to wait for the server to be ready here before sending the first stats
@@ -77,7 +77,6 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
         expected.emplace_back("sendRecv.kiki:-1|c");
 
         // Adjusts "toto" by +2
-        client.seed(19);  // this seed gets a hit on the first call
         client.count("toto", 2, 0.1f);
         throwOnError(client);
         expected.emplace_back("sendRecv.toto:2|c|@0.10");
@@ -97,7 +96,6 @@ void testSendRecv(uint64_t batchSize, uint64_t sendInterval) {
         expected.emplace_back("sendRecv.titifloat:-123.457|g");
 
         // Record a timing of 2ms for "myTiming"
-        client.seed(19);
         client.timing("myTiming", 2, 0.1f);
         throwOnError(client);
         expected.emplace_back("sendRecv.myTiming:2|ms|@0.10");


### PR DESCRIPTION
over in #12 we've clarified a few things to make the library threadsafe. there are a couple more little things to finish the job though largely the library is already threadsafe. this pr makes the use of the rng threadsafe by using thread local storage. additionally we remove the ability to change the internal state of the client via `setConfig` and `seed`. you're only option for configuration is up front or to make a new client which is certainly a clearer contract

the only thing left to do is fix the tests since the api has changed some of the tests are hard to keep in their current form

fixes #12 